### PR TITLE
Selective invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ Initially the bot will generate an empty `auth.json` file and likely throw an er
 ```
 
 (don't worry, that token is the one Discord publishes on its API docs)
+
+## Invite Links
+
+By default, the bot will not allow use of the `invite` command.  To enable it, fill in the inviteCode parameter in the auth.json file (add it as it won't show up on its own) with your bot's Client ID (**NOT** the Client Secret!)
+
+For example: {
+	"discord": "MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs",
+	"owner": "99326032288423936",
+	"inviteCode" : "12345678901234"
+}

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ Initially the bot will generate an empty `auth.json` file and likely throw an er
 
 By default, the bot will not allow use of the `invite` command.  To enable it, fill in the inviteCode parameter in the auth.json file (add it as it won't show up on its own) with your bot's Client ID (**NOT** the Client Secret!)
 
+```json
 For example: {
 	"discord": "MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs",
 	"owner": "99326032288423936",
 	"inviteCode" : "12345678901234"
 }
+```

--- a/bot.js
+++ b/bot.js
@@ -586,7 +586,7 @@ bot.cmds = {
 		usage: cfg =>  ["invite - sends the bot's oauth2 URL in this channel"],
 		permitted: (msg) => true,
 		execute: function(msg, args, cfg) {
-			send(msg.channel, "https://discordapp.com/api/oauth2/authorize?client_id=431544605209788416&permissions=805314560&scope=bot");
+			send(msg.channel, `https://discordapp.com/api/oauth2/authorize?client_id=${auth.inviteCode}&permissions=805314560&scope=bot`);
 		}
 	},
 	
@@ -791,6 +791,10 @@ bot.cmds = {
 		}
 	}
 };
+
+if (!auth.inviteCode) {
+	delete bot.cmds.invite;
+}
 
 function updateStatus() {
 	bot.editStatus({ name: `tul!help | ${Object.values(tulpae).reduce((acc,val) => acc + val.length, 0)} registered`});


### PR DESCRIPTION
Since private bots (based on the checkbox in the discord app setup) don't really have a use for the invite command (nobody but the owner can invite them anyways), this change sets up the bot so that it does not list the invite command, unless the bot's client ID has been set in auth.json as 'inviteCode'.